### PR TITLE
Allow arbitrary memory access

### DIFF
--- a/day_2/src/lib.rs
+++ b/day_2/src/lib.rs
@@ -19,7 +19,7 @@ pub mod day_2 {
 
         machine.execute_to_end(&mut std::iter::empty())?;
 
-        let result = machine.read_mem_elt(0);
+        let result = *machine.read_mem_elt(0).unwrap();
         Ok(result)
     }
 
@@ -39,7 +39,7 @@ pub mod day_2 {
                         machine.execute_to_end(&mut std::iter::empty()).ok()?;
                         // safety: on termination, program counter is on opcode 99,
                         // so there is an element in the array
-                        if machine.read_mem_elt(0) == target {
+                        if *machine.read_mem_elt(0).unwrap() == target {
                             Some((noun, verb))
                         } else {
                             None

--- a/day_2/src/lib.rs
+++ b/day_2/src/lib.rs
@@ -28,7 +28,7 @@ pub mod day_2 {
         T: IntoIterator<Item = usize>,
         T: Clone,
     {
-        let mut machine = MachineState::new();
+        let mut machine = MachineState::new_with_memory(&std::iter::empty());
         let (noun, verb) = (0..=99)
             .filter_map(|noun| {
                 (0..=99)

--- a/day_2/src/lib.rs
+++ b/day_2/src/lib.rs
@@ -13,14 +13,15 @@ pub mod day_2 {
         T: IntoIterator<Item = usize>,
         T: Clone,
     {
+        let num = num::usize();
         let mut machine = MachineState::new_with_memory(numbers);
-        machine.set_mem_elt(1, 12)?;
-        machine.set_mem_elt(2, 2)?;
+        machine.set_mem_elt(1, 12);
+        machine.set_mem_elt(2, 2);
 
-        machine.execute_to_end(&mut std::iter::empty(), &num::usize())?;
+        machine.execute_to_end(&mut std::iter::empty(), &num)?;
 
-        let result = machine.read_mem_elt(0)?;
-        Ok(*result)
+        let result = machine.read_mem_elt(0, &num);
+        Ok(result)
     }
 
     pub fn part_2<T>(numbers: &T, target: usize) -> usize
@@ -28,20 +29,21 @@ pub mod day_2 {
         T: IntoIterator<Item = usize>,
         T: Clone,
     {
+        let num = num::usize();
         let mut machine = MachineState::new();
         let (noun, verb) = (0..=99)
             .filter_map(|noun| {
                 (0..=99)
                     .filter_map(|verb| {
                         machine.reset(numbers.clone());
-                        machine.set_mem_elt(1, noun).ok()?;
-                        machine.set_mem_elt(2, verb).ok()?;
+                        machine.set_mem_elt(1, noun);
+                        machine.set_mem_elt(2, verb);
                         machine
                             .execute_to_end(&mut std::iter::empty(), &num::usize())
                             .ok()?;
                         // safety: on termination, program counter is on opcode 99,
                         // so there is an element in the array
-                        if *machine.read_mem_elt(0).unwrap() == target {
+                        if machine.read_mem_elt(0, &num) == target {
                             Some((noun, verb))
                         } else {
                             None

--- a/day_2/src/lib.rs
+++ b/day_2/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod day_2 {
-    use intcode::intcode::{num, MachineExecutionError, MachineState};
+    use intcode::intcode::{MachineExecutionError, MachineState};
 
     pub fn input(s: &str) -> Vec<usize> {
         s.trim()
@@ -13,14 +13,13 @@ pub mod day_2 {
         T: IntoIterator<Item = usize>,
         T: Clone,
     {
-        let num = num::usize();
         let mut machine = MachineState::new_with_memory(numbers);
         machine.set_mem_elt(1, 12);
         machine.set_mem_elt(2, 2);
 
-        machine.execute_to_end(&mut std::iter::empty(), &num)?;
+        machine.execute_to_end(&mut std::iter::empty())?;
 
-        let result = machine.read_mem_elt(0, &num);
+        let result = machine.read_mem_elt(0);
         Ok(result)
     }
 
@@ -29,7 +28,6 @@ pub mod day_2 {
         T: IntoIterator<Item = usize>,
         T: Clone,
     {
-        let num = num::usize();
         let mut machine = MachineState::new();
         let (noun, verb) = (0..=99)
             .filter_map(|noun| {
@@ -38,12 +36,10 @@ pub mod day_2 {
                         machine.reset(numbers.clone());
                         machine.set_mem_elt(1, noun);
                         machine.set_mem_elt(2, verb);
-                        machine
-                            .execute_to_end(&mut std::iter::empty(), &num::usize())
-                            .ok()?;
+                        machine.execute_to_end(&mut std::iter::empty()).ok()?;
                         // safety: on termination, program counter is on opcode 99,
                         // so there is an element in the array
-                        if machine.read_mem_elt(0, &num) == target {
+                        if machine.read_mem_elt(0) == target {
                             Some((noun, verb))
                         } else {
                             None

--- a/day_2/src/lib.rs
+++ b/day_2/src/lib.rs
@@ -19,7 +19,7 @@ pub mod day_2 {
 
         machine.execute_to_end(&mut std::iter::empty())?;
 
-        let result = *machine.read_mem_elt(0).unwrap();
+        let result = machine.get_value(machine.read_mem_elt(0));
         Ok(result)
     }
 
@@ -39,7 +39,7 @@ pub mod day_2 {
                         machine.execute_to_end(&mut std::iter::empty()).ok()?;
                         // safety: on termination, program counter is on opcode 99,
                         // so there is an element in the array
-                        if *machine.read_mem_elt(0).unwrap() == target {
+                        if machine.get_value(machine.read_mem_elt(0)) == target {
                             Some((noun, verb))
                         } else {
                             None

--- a/day_5/src/lib.rs
+++ b/day_5/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod day_5 {
-    use intcode::intcode::num;
     use intcode::intcode::{MachineExecutionError, MachineState};
 
     pub fn input(s: &str) -> Vec<i32> {
@@ -15,7 +14,7 @@ pub mod day_5 {
         T: Clone,
     {
         let mut machine = MachineState::new_with_memory(numbers);
-        let outputs = machine.execute_to_end(&mut std::iter::once(1), &num::i32())?;
+        let outputs = machine.execute_to_end(&mut std::iter::once(1))?;
         let mut outputs_iter = outputs.iter().rev();
         let ans = *outputs_iter.next().unwrap();
         for &output in outputs_iter {
@@ -33,7 +32,7 @@ pub mod day_5 {
         T: Clone,
     {
         let mut machine = MachineState::new_with_memory(numbers);
-        let outputs = machine.execute_to_end(&mut std::iter::once(5), &num::i32())?;
+        let outputs = machine.execute_to_end(&mut std::iter::once(5))?;
         if outputs.len() != 1 {
             panic!("bad len {}", outputs.len())
         }

--- a/day_7/src/lib.rs
+++ b/day_7/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod day_7 {
     use std::array;
 
-    use intcode::intcode::StepIoResult;
     use intcode::intcode::{MachineExecutionError, MachineState};
+    use intcode::intcode::{Num, StepIoResult};
     use itertools::Itertools;
 
     pub fn input(s: &str) -> Vec<i32> {
@@ -118,6 +118,7 @@ pub mod day_7 {
     where
         I: IntoIterator<Item = T>,
         I: Clone,
+        T: Num,
     {
         for machine in machines {
             machine.reset(initial.clone());

--- a/day_7/src/lib.rs
+++ b/day_7/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod day_7 {
     use std::array;
 
-    use intcode::intcode::{num, StepIoResult};
+    use intcode::intcode::StepIoResult;
     use intcode::intcode::{MachineExecutionError, MachineState};
     use itertools::Itertools;
 
@@ -20,17 +20,13 @@ pub mod day_7 {
         Terminated,
     }
 
-    pub fn initialise<F, const N: usize>(
+    pub fn initialise<const N: usize>(
         phase: &[u8],
         machines: &mut [MachineState<i32>; N],
-        num: &num::NumImpl<i32, F>,
-    ) -> Result<(), MachineExecutionError>
-    where
-        F: Fn(i32) -> Option<usize>,
-    {
+    ) -> Result<(), MachineExecutionError> {
         for i in 0..N {
             let phase = phase[i];
-            match machines[i].execute_until_input(num)? {
+            match machines[i].execute_until_input()? {
                 StepIoResult::AwaitingInput(loc) => {
                     machines[i].set_mem_elt(loc, phase as i32);
                 }
@@ -44,15 +40,11 @@ pub mod day_7 {
 
     /// Runs until machine E emits a value, returning that value;
     /// or until all machines have halted, in which case you get back None.
-    fn execute<F, const N: usize>(
+    fn execute<const N: usize>(
         input_to_first: Option<i32>,
         readiness: &mut [ExecutionState<i32>; N],
         machines: &mut [MachineState<i32>; N],
-        num: &num::NumImpl<i32, F>,
-    ) -> Result<Option<i32>, MachineExecutionError>
-    where
-        F: Fn(i32) -> Option<usize>,
-    {
+    ) -> Result<Option<i32>, MachineExecutionError> {
         let mut first_input_consumed = false;
 
         loop {
@@ -62,7 +54,7 @@ pub mod day_7 {
                 match readiness[i] {
                     ExecutionState::Ready => {
                         progress_made = true;
-                        match machines[i].execute_until_input(num)? {
+                        match machines[i].execute_until_input()? {
                             StepIoResult::Terminated => {
                                 readiness[i] = ExecutionState::Terminated;
                             }
@@ -137,17 +129,16 @@ pub mod day_7 {
         T: IntoIterator<Item = i32>,
         T: Clone,
     {
-        let num = num::i32();
         let mut machines: [MachineState<_>; 5] =
             array::from_fn(|_| MachineState::new_with_memory(numbers));
 
         let mut best = i32::MIN;
 
         for phase in (0..=4).permutations(5) {
-            initialise(&phase, &mut machines, &num)?;
+            initialise(&phase, &mut machines)?;
             let mut readiness = [ExecutionState::<i32>::Ready; 5];
 
-            let result = execute(None, &mut readiness, &mut machines, &num)?.unwrap();
+            let result = execute(None, &mut readiness, &mut machines)?.unwrap();
             if result > best {
                 best = result;
             }
@@ -163,20 +154,19 @@ pub mod day_7 {
         T: IntoIterator<Item = i32>,
         T: Clone,
     {
-        let num = num::i32();
         let mut machines: [MachineState<_>; 5] =
             array::from_fn(|_| MachineState::new_with_memory(numbers));
 
         let mut best = i32::MIN;
 
         for phase in (5..=9).permutations(5) {
-            initialise(&phase, &mut machines, &num)?;
+            initialise(&phase, &mut machines)?;
 
             let mut readiness = [ExecutionState::<i32>::Ready; 5];
 
             let mut input_to_first = None;
 
-            while let Some(result) = execute(input_to_first, &mut readiness, &mut machines, &num)? {
+            while let Some(result) = execute(input_to_first, &mut readiness, &mut machines)? {
                 input_to_first = Some(result);
             }
 

--- a/day_7/src/lib.rs
+++ b/day_7/src/lib.rs
@@ -32,7 +32,7 @@ pub mod day_7 {
             let phase = phase[i];
             match machines[i].execute_until_input(num)? {
                 StepIoResult::AwaitingInput(loc) => {
-                    machines[i].set_mem_elt(loc, phase as i32)?;
+                    machines[i].set_mem_elt(loc, phase as i32);
                 }
                 _ => {
                     panic!("unexpected IO result from machine {i}");
@@ -80,10 +80,10 @@ pub mod day_7 {
                                 progress_made = true;
                                 match input_to_first {
                                     None => {
-                                        machines[0].set_mem_elt(loc, 0)?;
+                                        machines[0].set_mem_elt(loc, 0);
                                     }
                                     Some(input) => {
-                                        machines[0].set_mem_elt(loc, input)?;
+                                        machines[0].set_mem_elt(loc, input);
                                         readiness[N - 1] = ExecutionState::Ready;
                                     }
                                 }
@@ -94,7 +94,7 @@ pub mod day_7 {
                             match readiness[i - 1] {
                                 ExecutionState::OutputPending(output) => {
                                     progress_made = true;
-                                    machines[i].set_mem_elt(loc, output)?;
+                                    machines[i].set_mem_elt(loc, output);
                                     readiness[i] = ExecutionState::Ready;
                                     readiness[i - 1] = ExecutionState::Ready;
                                 }

--- a/intcode/src/intcode.rs
+++ b/intcode/src/intcode.rs
@@ -320,14 +320,14 @@ impl<T> MachineState<T> {
 
     pub fn read_mem_elt(&self, i: usize) -> T
     where
-        T: Clone + Num,
+        T: Num + Copy,
     {
         if i < self.memory.len() {
-            self.memory[i].clone()
+            self.memory[i]
         } else {
             match self.sparse_memory.get(&i) {
-                None => T::zero().clone(),
-                Some(entry) => entry.clone(),
+                None => T::zero(),
+                Some(entry) => *entry,
             }
         }
     }
@@ -341,10 +341,7 @@ impl<T> MachineState<T> {
             ParameterMode::Position => {
                 let pos = self.read_mem_elt(i);
                 let pos = T::to_usize(pos);
-                match pos {
-                    None => None,
-                    Some(pos) => Some(self.read_mem_elt(pos)),
-                }
+                pos.map(|x| self.read_mem_elt(x))
             }
         }
     }

--- a/intcode/src/intcode.rs
+++ b/intcode/src/intcode.rs
@@ -11,30 +11,41 @@ pub struct MachineState<T> {
     pc: usize,
 }
 
-pub mod num {
+pub trait Num {
+    fn zero() -> Self;
+    fn one() -> Self;
+    fn to_usize(self) -> Option<usize>;
+}
 
-    pub struct NumImpl<T, F>
-    where
-        F: Fn(T) -> Option<usize>,
-    {
-        pub to_usize: F,
-        pub zero: T,
-        pub one: T,
-    }
-    pub fn i32() -> NumImpl<i32, impl Fn(i32) -> Option<usize>> {
-        NumImpl {
-            to_usize: |x| if x < 0 { None } else { Some(x as usize) },
-            zero: 0,
-            one: 1,
-        }
+impl Num for i32 {
+    fn zero() -> Self {
+        0
     }
 
-    pub fn usize() -> NumImpl<usize, impl Fn(usize) -> Option<usize>> {
-        NumImpl {
-            to_usize: |x| Some(x),
-            zero: 0,
-            one: 1,
+    fn one() -> Self {
+        1
+    }
+
+    fn to_usize(self) -> Option<usize> {
+        if self < 0 {
+            None
+        } else {
+            Some(self as usize)
         }
+    }
+}
+
+impl Num for usize {
+    fn zero() -> Self {
+        0
+    }
+
+    fn one() -> Self {
+        1
+    }
+
+    fn to_usize(self) -> Option<usize> {
+        Some(self)
     }
 }
 
@@ -142,16 +153,14 @@ impl<T> MachineState<T> {
         self.sparse_memory.clear();
     }
 
-    fn process_binary_op<G, H>(
+    fn process_binary_op<G>(
         &mut self,
         opcode: usize,
         process: G,
-        num: &num::NumImpl<T, H>,
     ) -> Result<StepResult<T>, MachineExecutionError>
     where
-        T: Copy,
+        T: Copy + Num,
         G: Fn(T, T) -> T,
-        H: Fn(T) -> Option<usize>,
     {
         if opcode >= 10000 {
             return Err(MachineExecutionError::BadParameterMode(opcode));
@@ -160,40 +169,36 @@ impl<T> MachineState<T> {
             .ok_or(MachineExecutionError::BadParameterMode(opcode))?;
         let mode_2 = ParameterMode::of_int((opcode / 1000) % 10)
             .ok_or(MachineExecutionError::BadParameterMode(opcode))?;
-        let arg_1 = self.read_param(self.pc + 1, mode_1, num)?;
-        let arg_2 = self.read_param(self.pc + 2, mode_2, num)?;
+        let arg_1 = self.read_param(self.pc + 1, mode_1)?;
+        let arg_2 = self.read_param(self.pc + 2, mode_2)?;
 
-        let result_pos = self.read_mem_elt(self.pc + 3, num);
+        let result_pos = self.read_mem_elt(self.pc + 3);
 
         self.set_mem_elt(
-            (num.to_usize)(result_pos).ok_or(MemoryAccessError::Negative)?,
+            T::to_usize(result_pos).ok_or(MemoryAccessError::Negative)?,
             process(arg_1, arg_2),
         );
         self.pc += 4;
         Ok(StepResult::Stepped)
     }
 
-    pub fn one_step<G>(
-        &mut self,
-        num: &num::NumImpl<T, G>,
-    ) -> Result<StepResult<T>, MachineExecutionError>
+    pub fn one_step(&mut self) -> Result<StepResult<T>, MachineExecutionError>
     where
-        T: Add<T, Output = T> + Mul<T, Output = T> + Copy + std::cmp::Ord,
-        G: Fn(T) -> Option<usize>,
+        T: Add<T, Output = T> + Mul<T, Output = T> + Copy + std::cmp::Ord + Num,
     {
-        let opcode = self.read_mem_elt(self.pc, num);
-        let opcode: usize = (num.to_usize)(opcode).ok_or(MachineExecutionError::OutOfBounds(
+        let opcode = self.read_mem_elt(self.pc);
+        let opcode: usize = T::to_usize(opcode).ok_or(MachineExecutionError::OutOfBounds(
             MemoryAccessError::Negative,
         ))?;
         match opcode % 100 {
-            1_usize => self.process_binary_op(opcode, |a, b| a + b, num),
-            2 => self.process_binary_op(opcode, |a, b| a * b, num),
+            1_usize => self.process_binary_op(opcode, |a, b| a + b),
+            2 => self.process_binary_op(opcode, |a, b| a * b),
             3 => {
                 if opcode != 3 {
                     return Err(MachineExecutionError::BadParameterMode(opcode));
                 }
-                let location = self.read_mem_elt(self.pc + 1, num);
-                let location = (num.to_usize)(location).ok_or(MemoryAccessError::Negative)?;
+                let location = self.read_mem_elt(self.pc + 1);
+                let location = T::to_usize(location).ok_or(MemoryAccessError::Negative)?;
                 self.pc += 2;
                 Ok(StepResult::Io(StepIoResult::AwaitingInput(location)))
             }
@@ -205,11 +210,11 @@ impl<T> MachineState<T> {
                     .ok_or(MachineExecutionError::BadParameterMode(opcode))?;
                 let to_output = match mode {
                     ParameterMode::Position => {
-                        let addr = (num.to_usize)(self.read_mem_elt(self.pc + 1, num))
+                        let addr = T::to_usize(self.read_mem_elt(self.pc + 1))
                             .ok_or(MemoryAccessError::Negative)?;
-                        self.read_mem_elt(addr, num)
+                        self.read_mem_elt(addr)
                     }
-                    ParameterMode::Immediate => self.read_mem_elt(self.pc + 1, num),
+                    ParameterMode::Immediate => self.read_mem_elt(self.pc + 1),
                 };
                 self.pc += 2;
                 Ok(StepResult::Io(StepIoResult::Output(to_output)))
@@ -220,12 +225,12 @@ impl<T> MachineState<T> {
                 }
                 let mode_comparand = ParameterMode::of_int((opcode / 100) % 10)
                     .ok_or(MachineExecutionError::BadParameterMode(opcode))?;
-                let comparand = self.read_param(self.pc + 1, mode_comparand, num)?;
-                if comparand != num.zero {
+                let comparand = self.read_param(self.pc + 1, mode_comparand)?;
+                if comparand != T::zero() {
                     let mode_target = ParameterMode::of_int((opcode / 1000) % 10)
                         .ok_or(MachineExecutionError::BadParameterMode(opcode))?;
-                    let target = self.read_param(self.pc + 2, mode_target, num)?;
-                    self.pc = (num.to_usize)(target).ok_or(MemoryAccessError::Negative)?;
+                    let target = self.read_param(self.pc + 2, mode_target)?;
+                    self.pc = T::to_usize(target).ok_or(MemoryAccessError::Negative)?;
                 } else {
                     self.pc += 3;
                 }
@@ -237,27 +242,23 @@ impl<T> MachineState<T> {
                 }
                 let mode_comparand = ParameterMode::of_int((opcode / 100) % 10)
                     .ok_or(MachineExecutionError::BadParameterMode(opcode))?;
-                let comparand = self.read_param(self.pc + 1, mode_comparand, num)?;
-                if comparand == num.zero {
+                let comparand = self.read_param(self.pc + 1, mode_comparand)?;
+                if comparand == T::zero() {
                     let mode_target = ParameterMode::of_int((opcode / 1000) % 10)
                         .ok_or(MachineExecutionError::BadParameterMode(opcode))?;
-                    let target = self.read_param(self.pc + 2, mode_target, num)?;
-                    self.pc = (num.to_usize)(target).ok_or(MemoryAccessError::Negative)?;
+                    let target = self.read_param(self.pc + 2, mode_target)?;
+                    self.pc = T::to_usize(target).ok_or(MemoryAccessError::Negative)?;
                 } else {
                     self.pc += 3;
                 }
                 Ok(StepResult::Stepped)
             }
             7 => {
-                self.process_binary_op(opcode, |a, b| if a < b { num.one } else { num.zero }, num)?;
+                self.process_binary_op(opcode, |a, b| if a < b { T::one() } else { T::zero() })?;
                 Ok(StepResult::Stepped)
             }
             8 => {
-                self.process_binary_op(
-                    opcode,
-                    |a, b| if a == b { num.one } else { num.zero },
-                    num,
-                )?;
+                self.process_binary_op(opcode, |a, b| if a == b { T::one() } else { T::zero() })?;
                 Ok(StepResult::Stepped)
             }
             99 => {
@@ -270,16 +271,12 @@ impl<T> MachineState<T> {
         }
     }
 
-    pub fn execute_until_input<G>(
-        &mut self,
-        num: &num::NumImpl<T, G>,
-    ) -> Result<StepIoResult<T>, MachineExecutionError>
+    pub fn execute_until_input(&mut self) -> Result<StepIoResult<T>, MachineExecutionError>
     where
-        T: Add<T, Output = T> + Mul<T, Output = T> + Copy + Ord,
-        G: Fn(T) -> Option<usize>,
+        T: Add<T, Output = T> + Mul<T, Output = T> + Copy + Ord + Num,
     {
         loop {
-            match self.one_step(num)? {
+            match self.one_step()? {
                 StepResult::Io(res) => {
                     return Ok(res);
                 }
@@ -288,19 +285,14 @@ impl<T> MachineState<T> {
         }
     }
 
-    pub fn execute_to_end<G, I>(
-        &mut self,
-        get_input: &mut I,
-        num: &num::NumImpl<T, G>,
-    ) -> Result<Vec<T>, MachineExecutionError>
+    pub fn execute_to_end<I>(&mut self, get_input: &mut I) -> Result<Vec<T>, MachineExecutionError>
     where
-        T: Add<T, Output = T> + Mul<T, Output = T> + Copy + Ord,
+        T: Add<T, Output = T> + Mul<T, Output = T> + Copy + Ord + Num,
         I: Iterator<Item = T>,
-        G: Fn(T) -> Option<usize>,
     {
         let mut outputs = vec![];
         loop {
-            match self.execute_until_input(num)? {
+            match self.execute_until_input()? {
                 StepIoResult::Terminated => {
                     return Ok(outputs);
                 }
@@ -334,39 +326,32 @@ impl<T> MachineState<T> {
         }
     }
 
-    pub fn read_mem_elt<G>(&self, i: usize, num: &num::NumImpl<T, G>) -> T
+    pub fn read_mem_elt(&self, i: usize) -> T
     where
-        G: Fn(T) -> Option<usize>,
-        T: Clone,
+        T: Clone + Num,
     {
         if i < self.memory.len() {
             self.memory[i].clone()
         } else {
             match self.sparse_memory.get(&i) {
-                None => num.zero.clone(),
+                None => T::zero().clone(),
                 Some(entry) => entry.clone(),
             }
         }
     }
 
-    fn read_param<G>(
-        &self,
-        i: usize,
-        mode: ParameterMode,
-        num: &num::NumImpl<T, G>,
-    ) -> Result<T, MemoryAccessError>
+    fn read_param(&self, i: usize, mode: ParameterMode) -> Result<T, MemoryAccessError>
     where
-        T: Copy,
-        G: Fn(T) -> Option<usize>,
+        T: Copy + Num,
     {
         match mode {
-            ParameterMode::Immediate => Ok(self.read_mem_elt(i, num)),
+            ParameterMode::Immediate => Ok(self.read_mem_elt(i)),
             ParameterMode::Position => {
-                let pos = self.read_mem_elt(i, num);
-                let pos = (num.to_usize)(pos);
+                let pos = self.read_mem_elt(i);
+                let pos = T::to_usize(pos);
                 match pos {
                     None => Err(MemoryAccessError::Negative),
-                    Some(pos) => Ok(self.read_mem_elt(pos, num)),
+                    Some(pos) => Ok(self.read_mem_elt(pos)),
                 }
             }
         }
@@ -377,19 +362,17 @@ impl<T> MachineState<T> {
 mod tests {
     use super::*;
 
-    fn assert_machines_eq<T, I, G, const N: usize>(
+    fn assert_machines_eq<T, I, const N: usize>(
         initial: &[T; N],
         expected_memory: Option<&[T]>,
         input: &mut I,
         expected_output: &[T],
-        num: &num::NumImpl<T, G>,
     ) where
-        T: Add<T, Output = T> + Mul<T, Output = T> + Copy + Ord,
+        T: Add<T, Output = T> + Mul<T, Output = T> + Copy + Ord + Num,
         I: Iterator<Item = T>,
-        G: Fn(T) -> Option<usize>,
     {
         let mut machine: MachineState<T> = MachineState::<T>::new_with_memory(initial);
-        let output = machine.execute_to_end(input, num).unwrap();
+        let output = machine.execute_to_end(input).unwrap();
         match expected_memory {
             None => {}
             Some(expected_memory) => {
@@ -406,7 +389,6 @@ mod tests {
             Some(&[3500, 9, 10, 70, 2, 3, 11, 0, 99, 30, 40, 50]),
             &mut std::iter::empty(),
             &[],
-            &num::usize(),
         );
     }
 
@@ -417,7 +399,6 @@ mod tests {
             Some(&[2, 3, 0, 6, 99]),
             &mut std::iter::empty(),
             &[],
-            &num::usize(),
         );
     }
 
@@ -428,7 +409,6 @@ mod tests {
             Some(&[2, 4, 4, 5, 99, 9801]),
             &mut std::iter::empty(),
             &[],
-            &num::usize(),
         );
     }
 
@@ -439,45 +419,44 @@ mod tests {
             Some(&[30, 1, 1, 4, 2, 5, 6, 0, 99]),
             &mut std::iter::empty(),
             &[],
-            &num::usize(),
         );
     }
 
     #[test]
     fn day_5_1() {
         let program = [3, 9, 8, 9, 10, 9, 4, 9, 99, -1, 8];
-        assert_machines_eq(&program, None, &mut std::iter::once(8), &[1], &num::i32());
-        assert_machines_eq(&program, None, &mut std::iter::once(7), &[0], &num::i32());
+        assert_machines_eq(&program, None, &mut std::iter::once(8), &[1]);
+        assert_machines_eq(&program, None, &mut std::iter::once(7), &[0]);
     }
 
     #[test]
     fn day_5_2() {
         let program = [3, 9, 7, 9, 10, 9, 4, 9, 99, -1, 8];
-        assert_machines_eq(&program, None, &mut std::iter::once(8), &[0], &num::i32());
-        assert_machines_eq(&program, None, &mut std::iter::once(7), &[1], &num::i32());
-        assert_machines_eq(&program, None, &mut std::iter::once(9), &[0], &num::i32());
+        assert_machines_eq(&program, None, &mut std::iter::once(8), &[0]);
+        assert_machines_eq(&program, None, &mut std::iter::once(7), &[1]);
+        assert_machines_eq(&program, None, &mut std::iter::once(9), &[0]);
     }
 
     #[test]
     fn day_5_3() {
         let program = [3, 3, 1108, -1, 8, 3, 4, 3, 99];
-        assert_machines_eq(&program, None, &mut std::iter::once(8), &[1], &num::i32());
-        assert_machines_eq(&program, None, &mut std::iter::once(7), &[0], &num::i32());
+        assert_machines_eq(&program, None, &mut std::iter::once(8), &[1]);
+        assert_machines_eq(&program, None, &mut std::iter::once(7), &[0]);
     }
 
     #[test]
     fn day_5_4() {
         let program = [3, 3, 1107, -1, 8, 3, 4, 3, 99];
-        assert_machines_eq(&program, None, &mut std::iter::once(8), &[0], &num::i32());
-        assert_machines_eq(&program, None, &mut std::iter::once(7), &[1], &num::i32());
-        assert_machines_eq(&program, None, &mut std::iter::once(9), &[0], &num::i32());
+        assert_machines_eq(&program, None, &mut std::iter::once(8), &[0]);
+        assert_machines_eq(&program, None, &mut std::iter::once(7), &[1]);
+        assert_machines_eq(&program, None, &mut std::iter::once(9), &[0]);
     }
 
     #[test]
     fn day_5_6() {
         let program = [3, 3, 1105, -1, 9, 1101, 0, 0, 12, 4, 12, 99, 1];
-        assert_machines_eq(&program, None, &mut std::iter::once(0), &[0], &num::i32());
-        assert_machines_eq(&program, None, &mut std::iter::once(3), &[1], &num::i32());
+        assert_machines_eq(&program, None, &mut std::iter::once(0), &[0]);
+        assert_machines_eq(&program, None, &mut std::iter::once(3), &[1]);
     }
 
     #[test]
@@ -487,20 +466,8 @@ mod tests {
             0, 1002, 21, 125, 20, 4, 20, 1105, 1, 46, 104, 999, 1105, 1, 46, 1101, 1000, 1, 20, 4,
             20, 1105, 1, 46, 98, 99,
         ];
-        assert_machines_eq(&program, None, &mut std::iter::once(7), &[999], &num::i32());
-        assert_machines_eq(
-            &program,
-            None,
-            &mut std::iter::once(8),
-            &[1000],
-            &num::i32(),
-        );
-        assert_machines_eq(
-            &program,
-            None,
-            &mut std::iter::once(9),
-            &[1001],
-            &num::i32(),
-        );
+        assert_machines_eq(&program, None, &mut std::iter::once(7), &[999]);
+        assert_machines_eq(&program, None, &mut std::iter::once(8), &[1000]);
+        assert_machines_eq(&program, None, &mut std::iter::once(9), &[1001]);
     }
 }

--- a/intcode/src/intcode.rs
+++ b/intcode/src/intcode.rs
@@ -139,6 +139,7 @@ impl<T> MachineState<T> {
         self.pc = 0;
         self.memory.clear();
         self.memory.extend(mem);
+        self.sparse_memory.clear();
     }
 
     fn process_binary_op<G, H>(

--- a/intcode/src/intcode.rs
+++ b/intcode/src/intcode.rs
@@ -153,11 +153,13 @@ impl<T> MachineState<T> {
             .ok_or(MachineExecutionError::BadParameterMode(opcode))?;
         let arg_1 = self
             .read_param(self.pc + 1, mode_1)
-            .map_err(|()| MachineExecutionError::OutOfBounds)?.copied()
+            .map_err(|()| MachineExecutionError::OutOfBounds)?
+            .copied()
             .unwrap_or(T::zero());
         let arg_2 = self
             .read_param(self.pc + 2, mode_2)
-            .map_err(|()| MachineExecutionError::OutOfBounds)?.copied()
+            .map_err(|()| MachineExecutionError::OutOfBounds)?
+            .copied()
             .unwrap_or(T::zero());
 
         let result_pos = match self.read_mem_elt(self.pc + 3) {
@@ -353,10 +355,7 @@ impl<T> MachineState<T> {
     // All outcomes are "success". A None result means the memory is not
     // yet initialised (so is implicitly 0), and is outside the dense array storage.
     pub fn read_mem_elt(&self, i: usize) -> Option<&T> {
-        match self.memory.get(i) {
-            None => self.sparse_memory.get(&i),
-            Some(mem) => Some(mem),
-        }
+        self.memory.get(i).or_else(|| self.sparse_memory.get(&i))
     }
 
     // Success outcome:


### PR DESCRIPTION
Pulled out of #8 . As of ac31cca this is the cause of the performance regression. Merely adding the hashmap to the struct is not the cause of the regression.